### PR TITLE
Add simple Node.js server for BadGirlChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # BadGirlChat
 
-Open `index.html` in a modern browser to run the un-censored BadChat app. The single-page application is optimized for tablet and desktop use and includes chat, photo and memory management, a character editor, and sync/debug overlays.
+BadGirlChat ist eine Einzeldatei-Webanwendung. Du kannst `index.html` direkt im Browser öffnen oder einen kleinen Node.js-Server starten.
+
+## Lokalen Server starten
+
+```bash
+npm start
+```
+
+Anschließend ist die App unter [http://localhost:3000](http://localhost:3000) erreichbar.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "badgirlchat",
+  "version": "1.0.0",
+  "description": "Single-page chat application served via Node HTTP server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(__dirname, urlPath);
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml'
+  };
+  const contentType = mimeTypes[ext] || 'text/plain';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Server error');
+      }
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`BadGirlChat server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- Add minimal Node HTTP server to serve the single-page application
- Provide npm start and test scripts
- Document how to run the app via `npm start`

## Testing
- `npm test`
- `npm start` (shows server running and was terminated)

------
https://chatgpt.com/codex/tasks/task_e_68996d4db3a8832f8fb5f41e5a498a77